### PR TITLE
Improve ZW parsing and prompt

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -571,7 +571,7 @@ Scenario: "${nlScenario}"
                 prompt += `\nSchema Name: ${schema.name}\n${schema.definition}\n---\n`;
             });
         } else {
-            prompt += "\nNo specific project templates provided. Infer a suitable ZW structure.\n";
+            prompt += "\nNo specific project templates provided. Infer a suitable ZW structure and start the packet with 'ZW-INFERRED-DATA:' on its own line.\n";
         }
     }
 


### PR DESCRIPTION
## Summary
- make `zwParser` strip common markdown code fences and show first line when root parsing fails
- instruct Gemini to start inferred packets with `ZW-INFERRED-DATA:`

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: React types missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843e189d334832d94f801b8c6e1199b