### PR TITLE
Add AI service and Ollama client

### DIFF
--- a/aiService.ts
+++ b/aiService.ts
@@ -1,0 +1,183 @@
+import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
+import { OllamaClient, OllamaModel } from './ollamaClient';
+
+export type AIProvider = 'gemini' | 'ollama';
+
+export interface AIConfig {
+  provider: AIProvider;
+  geminiApiKey?: string;
+  ollamaBaseUrl?: string;
+  ollamaModel?: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export class AIService {
+  private geminiClient: GoogleGenAI | null = null;
+  private ollamaClient: OllamaClient | null = null;
+  private config: AIConfig;
+
+  constructor(config: AIConfig) {
+    this.config = config;
+    this.initializeClients();
+  }
+
+  private initializeClients() {
+    // Initialize Gemini if API key is provided
+    if (this.config.geminiApiKey) {
+      try {
+        this.geminiClient = new GoogleGenAI({ apiKey: this.config.geminiApiKey });
+      } catch (error) {
+        console.error('Failed to initialize Gemini client:', error);
+      }
+    }
+
+    // Initialize Ollama
+    this.ollamaClient = new OllamaClient(this.config.ollamaBaseUrl);
+  }
+
+  async testConnection(): Promise<{ gemini: boolean; ollama: boolean }> {
+    const results = {
+      gemini: false,
+      ollama: false
+    };
+
+    // Test Gemini
+    if (this.geminiClient) {
+      try {
+        // Simple test request
+        const response = await this.geminiClient.models.generateContent({
+          model: 'gemini-2.5-flash-preview-04-17',
+          contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        });
+        results.gemini = !!response.text;
+      } catch (error) {
+        console.error('Gemini connection test failed:', error);
+      }
+    }
+
+    // Test Ollama
+    if (this.ollamaClient) {
+      results.ollama = await this.ollamaClient.testConnection();
+    }
+
+    return results;
+  }
+
+  async getAvailableModels(): Promise<{ gemini: string[]; ollama: OllamaModel[] }> {
+    const models = {
+      gemini: ['gemini-2.5-flash-preview-04-17', 'gemini-2.0-flash-thinking-exp', 'gemini-1.5-pro'],
+      ollama: [] as OllamaModel[]
+    };
+
+    if (this.ollamaClient) {
+      try {
+        models.ollama = await this.ollamaClient.listModels();
+      } catch (error) {
+        console.error('Failed to get Ollama models:', error);
+      }
+    }
+
+    return models;
+  }
+
+  async generateText(prompt: string, options?: {
+    provider?: AIProvider;
+    model?: string;
+    temperature?: number;
+    stream?: boolean;
+    onStream?: (chunk: string) => void;
+  }): Promise<string> {
+    const provider = options?.provider || this.config.provider;
+    const temperature = options?.temperature || this.config.temperature || 0.7;
+
+    if (provider === 'gemini' && this.geminiClient) {
+      return this.generateWithGemini(prompt, options?.model, temperature);
+    } else if (provider === 'ollama' && this.ollamaClient) {
+      const model = options?.model || this.config.ollamaModel || 'llama3.2:latest';
+      
+      if (options?.stream && options?.onStream) {
+        let fullResponse = '';
+        await this.ollamaClient.generateStream(
+          {
+            model,
+            prompt,
+            options: { temperature }
+          },
+          (chunk) => {
+            fullResponse += chunk;
+            options.onStream!(chunk);
+          }
+        );
+        return fullResponse;
+      } else {
+        return this.ollamaClient.generate({
+          model,
+          prompt,
+          options: { temperature }
+        });
+      }
+    } else {
+      throw new Error(`AI provider ${provider} not available or not configured`);
+    }
+  }
+
+  private async generateWithGemini(prompt: string, model?: string, temperature?: number): Promise<string> {
+    if (!this.geminiClient) {
+      throw new Error('Gemini client not initialized');
+    }
+
+    const response: GenerateContentResponse = await this.geminiClient.models.generateContent({
+      model: model || 'gemini-2.5-flash-preview-04-17',
+      contents: [{ role: "user", parts: [{ text: prompt }] }],
+    });
+
+    return response.text.trim();
+  }
+
+  updateConfig(newConfig: Partial<AIConfig>) {
+    this.config = { ...this.config, ...newConfig };
+    this.initializeClients();
+  }
+
+  async pullOllamaModel(modelName: string, onProgress?: (progress: string) => void): Promise<void> {
+    if (!this.ollamaClient) {
+      throw new Error('Ollama client not initialized');
+    }
+    
+    return this.ollamaClient.pullModel(modelName, onProgress);
+  }
+}
+
+export const createAIService = (config: AIConfig): AIService => {
+  return new AIService(config);
+};
+
+export const RECOMMENDED_OLLAMA_MODELS = [
+  {
+    name: 'llama3.2:latest',
+    description: 'Fast, general-purpose model good for ZW generation',
+    size: '2.0GB',
+    recommended: true
+  },
+  {
+    name: 'codellama:latest',
+    description: 'Specialized for code-like structures, excellent for ZW syntax',
+    size: '3.8GB',
+    recommended: true
+  },
+  {
+    name: 'mistral:latest',
+    description: 'Excellent at following structured formats like ZW',
+    size: '4.1GB',
+    recommended: false
+  },
+  {
+    name: 'phi3:latest',
+    description: 'Lightweight model, good for quick validations',
+    size: '2.3GB',
+    recommended: false
+  }
+];
+
+export default AIService;

--- a/ollamaClient.ts
+++ b/ollamaClient.ts
@@ -1,0 +1,225 @@
+export interface OllamaResponse {
+  model: string;
+  response: string;
+  done: boolean;
+  context?: number[];
+  total_duration?: number;
+  load_duration?: number;
+  prompt_eval_count?: number;
+  prompt_eval_duration?: number;
+  eval_count?: number;
+  eval_duration?: number;
+}
+
+export interface OllamaGenerateRequest {
+  model: string;
+  prompt: string;
+  stream?: boolean;
+  context?: number[];
+  options?: {
+    temperature?: number;
+    top_p?: number;
+    top_k?: number;
+    num_predict?: number;
+    stop?: string[];
+  };
+}
+
+export interface OllamaModel {
+  name: string;
+  modified_at: string;
+  size: number;
+  digest: string;
+  details: {
+    format: string;
+    family: string;
+    families?: string[];
+    parameter_size: string;
+    quantization_level: string;
+  };
+}
+
+export class OllamaClient {
+  private baseUrl: string;
+  private timeout: number;
+
+  constructor(baseUrl: string = 'http://localhost:11434', timeout: number = 30000) {
+    this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    this.timeout = timeout;
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/tags`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(5000)
+      });
+      return response.ok;
+    } catch (error) {
+      console.error('Ollama connection test failed:', error);
+      return false;
+    }
+  }
+
+  async listModels(): Promise<OllamaModel[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/tags`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(this.timeout)
+      });
+      
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      
+      const data = await response.json();
+      return data.models || [];
+    } catch (error) {
+      console.error('Failed to list Ollama models:', error);
+      throw error;
+    }
+  }
+
+  async generate(request: OllamaGenerateRequest): Promise<string> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/generate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...request,
+          stream: false // Force non-streaming for now
+        }),
+        signal: AbortSignal.timeout(this.timeout)
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data: OllamaResponse = await response.json();
+      return data.response;
+    } catch (error) {
+      console.error('Ollama generation failed:', error);
+      throw error;
+    }
+  }
+
+  async generateStream(
+    request: OllamaGenerateRequest,
+    onChunk: (chunk: string) => void,
+    onComplete?: () => void
+  ): Promise<void> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/generate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...request,
+          stream: true
+        }),
+        signal: AbortSignal.timeout(this.timeout)
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error('No response body reader available');
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        
+        if (done) break;
+        
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        
+        // Process complete lines, keep incomplete line in buffer
+        buffer = lines.pop() || '';
+        
+        for (const line of lines) {
+          if (line.trim()) {
+            try {
+              const data: OllamaResponse = JSON.parse(line);
+              onChunk(data.response);
+              
+              if (data.done) {
+                onComplete?.();
+                return;
+              }
+            } catch (e) {
+              console.warn('Failed to parse streaming response line:', line);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Ollama streaming generation failed:', error);
+      throw error;
+    }
+  }
+
+  async pullModel(modelName: string, onProgress?: (progress: string) => void): Promise<void> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/pull`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: modelName,
+          stream: true
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error('No response body reader available');
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        
+        if (done) break;
+        
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        
+        buffer = lines.pop() || '';
+        
+        for (const line of lines) {
+          if (line.trim()) {
+            try {
+              const data = JSON.parse(line);
+              if (data.status && onProgress) {
+                onProgress(data.status);
+              }
+            } catch (e) {
+              console.warn('Failed to parse pull response line:', line);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Ollama model pull failed:', error);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an Ollama client helper for querying and pulling models
- add AI service wrapper that supports Gemini and Ollama

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e51b42e4832dbd13d0ecd13afe49