### PR TITLE
Integrate simplified AI service with Ollama

### DIFF
--- a/ollamaClient.ts
+++ b/ollamaClient.ts
@@ -1,97 +1,26 @@
 export interface OllamaResponse {
-  model: string;
   response: string;
   done: boolean;
-  context?: number[];
-  total_duration?: number;
-  load_duration?: number;
-  prompt_eval_count?: number;
-  prompt_eval_duration?: number;
-  eval_count?: number;
-  eval_duration?: number;
-}
-
-export interface OllamaGenerateRequest {
-  model: string;
-  prompt: string;
-  stream?: boolean;
-  context?: number[];
-  options?: {
-    temperature?: number;
-    top_p?: number;
-    top_k?: number;
-    num_predict?: number;
-    stop?: string[];
-  };
-}
-
-export interface OllamaModel {
-  name: string;
-  modified_at: string;
-  size: number;
-  digest: string;
-  details: {
-    format: string;
-    family: string;
-    families?: string[];
-    parameter_size: string;
-    quantization_level: string;
-  };
 }
 
 export class OllamaClient {
   private baseUrl: string;
-  private timeout: number;
 
-  constructor(baseUrl: string = 'http://localhost:11434', timeout: number = 30000) {
-    this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-    this.timeout = timeout;
+  constructor(baseUrl: string = 'http://localhost:11434') {
+    this.baseUrl = baseUrl;
   }
 
-  async testConnection(): Promise<boolean> {
-    try {
-      const response = await fetch(`${this.baseUrl}/api/tags`, {
-        method: 'GET',
-        signal: AbortSignal.timeout(5000)
-      });
-      return response.ok;
-    } catch (error) {
-      console.error('Ollama connection test failed:', error);
-      return false;
-    }
-  }
-
-  async listModels(): Promise<OllamaModel[]> {
-    try {
-      const response = await fetch(`${this.baseUrl}/api/tags`, {
-        method: 'GET',
-        signal: AbortSignal.timeout(this.timeout)
-      });
-      
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      
-      const data = await response.json();
-      return data.models || [];
-    } catch (error) {
-      console.error('Failed to list Ollama models:', error);
-      throw error;
-    }
-  }
-
-  async generate(request: OllamaGenerateRequest): Promise<string> {
+  async generate(model: string, prompt: string, temperature: number = 0.5): Promise<string> {
     try {
       const response = await fetch(`${this.baseUrl}/api/generate`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          ...request,
-          stream: false // Force non-streaming for now
-        }),
-        signal: AbortSignal.timeout(this.timeout)
+          model,
+          prompt,
+          stream: false,
+          options: { temperature }
+        })
       });
 
       if (!response.ok) {
@@ -106,120 +35,12 @@ export class OllamaClient {
     }
   }
 
-  async generateStream(
-    request: OllamaGenerateRequest,
-    onChunk: (chunk: string) => void,
-    onComplete?: () => void
-  ): Promise<void> {
+  async testConnection(): Promise<boolean> {
     try {
-      const response = await fetch(`${this.baseUrl}/api/generate`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          ...request,
-          stream: true
-        }),
-        signal: AbortSignal.timeout(this.timeout)
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error('No response body reader available');
-      }
-
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      while (true) {
-        const { done, value } = await reader.read();
-        
-        if (done) break;
-        
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        
-        // Process complete lines, keep incomplete line in buffer
-        buffer = lines.pop() || '';
-        
-        for (const line of lines) {
-          if (line.trim()) {
-            try {
-              const data: OllamaResponse = JSON.parse(line);
-              onChunk(data.response);
-              
-              if (data.done) {
-                onComplete?.();
-                return;
-              }
-            } catch (e) {
-              console.warn('Failed to parse streaming response line:', line);
-            }
-          }
-        }
-      }
-    } catch (error) {
-      console.error('Ollama streaming generation failed:', error);
-      throw error;
-    }
-  }
-
-  async pullModel(modelName: string, onProgress?: (progress: string) => void): Promise<void> {
-    try {
-      const response = await fetch(`${this.baseUrl}/api/pull`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          name: modelName,
-          stream: true
-        })
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error('No response body reader available');
-      }
-
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      while (true) {
-        const { done, value } = await reader.read();
-        
-        if (done) break;
-        
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        
-        buffer = lines.pop() || '';
-        
-        for (const line of lines) {
-          if (line.trim()) {
-            try {
-              const data = JSON.parse(line);
-              if (data.status && onProgress) {
-                onProgress(data.status);
-              }
-            } catch (e) {
-              console.warn('Failed to parse pull response line:', line);
-            }
-          }
-        }
-      }
-    } catch (error) {
-      console.error('Ollama model pull failed:', error);
-      throw error;
+      const response = await fetch(`${this.baseUrl}/api/tags`);
+      return response.ok;
+    } catch {
+      return false;
     }
   }
 }

--- a/simpleAiService.ts
+++ b/simpleAiService.ts
@@ -1,0 +1,61 @@
+import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
+import { OllamaClient } from './ollamaClient';
+
+export type AIProvider = 'gemini' | 'ollama';
+
+export interface SimpleAIConfig {
+  provider: AIProvider;
+  geminiApiKey?: string;
+  ollamaModel?: string;
+  temperature?: number;
+}
+
+export class SimpleAIService {
+  private geminiClient: GoogleGenAI | null = null;
+  private ollamaClient: OllamaClient;
+  private config: SimpleAIConfig;
+
+  constructor(config: SimpleAIConfig) {
+    this.config = config;
+    this.ollamaClient = new OllamaClient();
+    
+    if (config.geminiApiKey) {
+      try {
+        this.geminiClient = new GoogleGenAI({ apiKey: config.geminiApiKey });
+      } catch (error) {
+        console.error('Failed to initialize Gemini:', error);
+      }
+    }
+  }
+
+  async generateText(prompt: string): Promise<string> {
+    const temperature = this.config.temperature || 0.5;
+
+    if (this.config.provider === 'ollama') {
+      const model = this.config.ollamaModel || 'dolphin-mistral:latest';
+      return this.ollamaClient.generate(model, prompt, temperature);
+    } 
+    else if (this.config.provider === 'gemini' && this.geminiClient) {
+      const response: GenerateContentResponse = await this.geminiClient.models.generateContent({
+        model: 'gemini-2.5-flash-preview-04-17',
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+      });
+      return response.text.trim();
+    } 
+    else {
+      throw new Error(`AI provider ${this.config.provider} not available`);
+    }
+  }
+
+  async testConnection(): Promise<{ ollama: boolean; gemini: boolean }> {
+    const results = { ollama: false, gemini: false };
+    
+    // Test Ollama
+    results.ollama = await this.ollamaClient.testConnection();
+    
+    // Test Gemini (simple check)
+    results.gemini = !!this.geminiClient;
+    
+    return results;
+  }
+}


### PR DESCRIPTION
## Summary
- replace heavy Ollama client with minimal version
- add `simpleAiService` wrapper for Gemini and Ollama
- update `index.tsx` to use new service and provider toggle

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6847ed4e3b80832d84b4c547cad243ec