### PR TITLE
Add Ollama model selection

### DIFF
--- a/ollamaClient.ts
+++ b/ollamaClient.ts
@@ -3,6 +3,18 @@ export interface OllamaResponse {
   done: boolean;
 }
 
+// Fetch a list of available models from a local Ollama server
+export async function getAvailableModels(): Promise<string[]> {
+  try {
+    const response = await fetch('http://localhost:11434/api/tags');
+    const data = await response.json();
+    return data.models?.map((model: any) => model.name) || [];
+  } catch (error) {
+    console.error('Failed to fetch Ollama models:', error);
+    return ['dolphin-mistral:latest'];
+  }
+}
+
 export class OllamaClient {
   private baseUrl: string;
 

--- a/simpleAiService.ts
+++ b/simpleAiService.ts
@@ -28,13 +28,13 @@ export class SimpleAIService {
     }
   }
 
-  async generateText(prompt: string): Promise<string> {
+  async generateText(prompt: string, model?: string): Promise<string> {
     const temperature = this.config.temperature || 0.5;
 
     if (this.config.provider === 'ollama') {
-      const model = this.config.ollamaModel || 'dolphin-mistral:latest';
-      return this.ollamaClient.generate(model, prompt, temperature);
-    } 
+      const selectedModel = model || this.config.ollamaModel || 'dolphin-mistral:latest';
+      return this.ollamaClient.generate(selectedModel, prompt, temperature);
+    }
     else if (this.config.provider === 'gemini' && this.geminiClient) {
       const response: GenerateContentResponse = await this.geminiClient.models.generateContent({
         model: 'gemini-2.5-flash-preview-04-17',


### PR DESCRIPTION
## Summary
- add `getAvailableModels` helper in ollama client
- allow selecting an ollama model in UI
- load models from local server when Ollama provider is active
- pass selected model to AI generation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2d6a2b60832d96cf079c71369ce8